### PR TITLE
Add CPU attention cache example

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,6 +39,7 @@ endif()
 find_package(Threads REQUIRED)
 
 add_subdirectory(src)
+add_subdirectory(examples)
 set(LLAMA_BUILD_SERVER ON CACHE BOOL "Build llama.cpp server" FORCE)
 add_subdirectory(3rdparty/llama.cpp)
 

--- a/README.md
+++ b/README.md
@@ -245,6 +245,14 @@ optional arguments:
                         (When this option is turned on, the prompt specified by -p will be used as the system prompt.)
 </pre>
 
+### CPU caching example
+The repository also includes a lightweight PyTorch model for CPU in `cpu/model.py`. It uses `CachedSelfAttention` to store key/value tensors between decoding steps. Call `reset_cache()` before starting a new sequence. A minimal C++ version is provided in `examples/kv_cache_example.cpp` and can be built with CMake:
+
+```bash
+cmake -S examples -B build
+cmake --build build
+```
+
 ### Benchmark
 We provide scripts to run the inference benchmark providing a model.
 

--- a/cpu/__init__.py
+++ b/cpu/__init__.py
@@ -1,0 +1,1 @@
+from .model import ModelArgs, Transformer

--- a/cpu/model.py
+++ b/cpu/model.py
@@ -1,0 +1,56 @@
+from dataclasses import dataclass
+
+import torch
+from torch import nn
+
+from utils.cache_kv_attention import CachedSelfAttention
+
+
+@dataclass
+class ModelArgs:
+    """Configuration for the simple CPU Transformer."""
+    vocab_size: int = 50257
+    dim: int = 768
+    n_layers: int = 12
+    n_heads: int = 12
+    ffn_dim: int = 3072
+
+
+class TransformerBlock(nn.Module):
+    def __init__(self, args: ModelArgs) -> None:
+        super().__init__()
+        self.attn = CachedSelfAttention(args.dim, args.n_heads)
+        self.ffn = nn.Sequential(
+            nn.Linear(args.dim, args.ffn_dim),
+            nn.GELU(),
+            nn.Linear(args.ffn_dim, args.dim),
+        )
+        self.attn_norm = nn.LayerNorm(args.dim)
+        self.ffn_norm = nn.LayerNorm(args.dim)
+
+    def forward(self, x: torch.Tensor, use_cache: bool = False) -> torch.Tensor:
+        h = x + self.attn(self.attn_norm(x), use_cache=use_cache)
+        h = h + self.ffn(self.ffn_norm(h))
+        return h
+
+
+class Transformer(nn.Module):
+    def __init__(self, args: ModelArgs) -> None:
+        super().__init__()
+        self.args = args
+        self.tok_embeddings = nn.Embedding(args.vocab_size, args.dim)
+        self.layers = nn.ModuleList([TransformerBlock(args) for _ in range(args.n_layers)])
+        self.norm = nn.LayerNorm(args.dim)
+        self.output = nn.Linear(args.dim, args.vocab_size, bias=False)
+
+    def reset_cache(self) -> None:
+        """Clear cached key/value tensors in all layers."""
+        for layer in self.layers:
+            layer.attn.reset_cache()
+
+    def forward(self, token_ids: torch.Tensor, use_cache: bool = False) -> torch.Tensor:
+        h = self.tok_embeddings(token_ids)
+        for layer in self.layers:
+            h = layer(h, use_cache=use_cache)
+        logits = self.output(self.norm(h))
+        return logits

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,0 +1,4 @@
+cmake_minimum_required(VERSION 3.14)
+project(kv_cache_example CXX)
+
+add_executable(kv_cache_example kv_cache_example.cpp)

--- a/examples/kv_cache_example.cpp
+++ b/examples/kv_cache_example.cpp
@@ -1,0 +1,72 @@
+#include <vector>
+#include <iostream>
+#include <cmath>
+
+class CachedSelfAttention {
+public:
+    CachedSelfAttention(int dim, int heads)
+        : dim_(dim), heads_(heads), head_dim_(dim / heads) {}
+
+    void reset_cache() {
+        cache_k_.clear();
+        cache_v_.clear();
+    }
+
+    std::vector<float> forward(const std::vector<float>& x, bool use_cache) {
+        int seq_len = x.size() / dim_;
+        std::vector<float> q = x;
+        std::vector<float> k = x;
+        std::vector<float> v = x;
+
+        if (use_cache && !cache_k_.empty()) {
+            k.insert(k.begin(), cache_k_.begin(), cache_k_.end());
+            v.insert(v.begin(), cache_v_.begin(), cache_v_.end());
+        }
+
+        if (use_cache) {
+            cache_k_ = k;
+            cache_v_ = v;
+        }
+
+        int total_len = k.size() / dim_;
+        std::vector<float> out(seq_len * dim_, 0.0f);
+
+        for (int h = 0; h < heads_; ++h) {
+            int offset = h * head_dim_;
+            for (int i = 0; i < seq_len; ++i) {
+                for (int j = 0; j < total_len; ++j) {
+                    float score = 0.0f;
+                    for (int d = 0; d < head_dim_; ++d) {
+                        score += q[i * dim_ + offset + d] * k[j * dim_ + offset + d];
+                    }
+                    score /= std::sqrt(static_cast<float>(head_dim_));
+                    for (int d = 0; d < head_dim_; ++d) {
+                        out[i * dim_ + offset + d] += score * v[j * dim_ + offset + d];
+                    }
+                }
+            }
+        }
+
+        return out;
+    }
+
+private:
+    int dim_;
+    int heads_;
+    int head_dim_;
+    std::vector<float> cache_k_;
+    std::vector<float> cache_v_;
+};
+
+int main() {
+    CachedSelfAttention attn(8, 2);
+    std::vector<float> step1(8, 1.0f);
+    auto out1 = attn.forward(step1, true);
+
+    std::vector<float> step2(8, 2.0f);
+    auto out2 = attn.forward(step2, true);
+
+    std::cout << "cached sequence length: " << out2.size() / 8 << std::endl;
+    attn.reset_cache();
+    return 0;
+}


### PR DESCRIPTION
## Summary
- add a small CPU Transformer that caches key/value tensors via `CachedSelfAttention`
- mention the CPU caching example in the README
- provide a C++ example to cache keys/values using CMake

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`
- `cmake -S examples -B build && cmake --build build`


------
https://chatgpt.com/codex/tasks/task_e_6856cc0b0a14832886de2f0a84b923ae